### PR TITLE
Fix issue with small images

### DIFF
--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -128,6 +128,9 @@ class Responsive extends Tags
         return $widths
             /* If a width is specified, consider it a max width */
             ->when(isset($params['width']) || isset($params['w']), function ($widths) use ($params) {
+                if ($widths->first() >= $params['width'] ?? $params['w']) {
+                    return collect($widths->first());
+                }
                 return $widths->filter(function (int $width) use ($params) {
                     return $width <= $params['width'] ?? $params['w'];
                 });


### PR DESCRIPTION
This PR fixes an issue with missing `srcset` with small images.

Let's say we have a large image of `6000x4000px`. To prevent generating a large number of images, we set the `glide:width` parameter to the maximum required size: `{{ responsive:image glide:width="200" }}`.

If the provided width of `200` is smaller than the smallest width calculated by the `WidthCalculator`, the returned `$widths` will be empty. This results in only having the placeholder image in the `srcset`. Which in return will only ever show the blurred image.

This fix first checks, if the smallest width is larger or equal to the provided width parameter. If it is, it will return it.