### PR TITLE
Allow setting attributes on the picture tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ If you want to add additional attributes (for example a title attribute) to your
 {{ responsive:image_field alt="{title}" class="my-class" }}
 ```
 
+Additional attributes prefixed with `picture:` will be added to the picture tag.
+
+```twig
+{{ responsive:image_field picture:class="my-class" picture:data-stuff="hello" }}
+```
+
 ## Customizing the generated html
 
 If you want to customize the generated html, you can publish the views using

--- a/resources/views/responsiveImage.antlers.html
+++ b/resources/views/responsiveImage.antlers.html
@@ -1,4 +1,4 @@
-<picture>
+<picture {{ pictureAttributeString }}>
     {{ if srcSetWebp }}<source type="image/webp" srcset="{{ srcSetWebp }}" />{{ /if }}
     <source srcset="{{ srcSet }}" />
     <img

--- a/resources/views/responsiveImageWithPlaceholder.antlers.html
+++ b/resources/views/responsiveImageWithPlaceholder.antlers.html
@@ -1,4 +1,4 @@
-<picture>
+<picture {{ pictureAttributeString }}>
     {{ if srcSetWebp }}<source type="image/webp" srcset="{{ srcSetWebp }}" sizes="1px" />{{ /if }}
     <source srcset="{{ srcSet }}" sizes="1px" />
     <img

--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -80,6 +80,7 @@ class Responsive extends Tags
         if ($asset->extension() === "svg") {
             return view('responsive-images::responsiveImage', [
                 'attributeString' => $this->getAttributeString(),
+                'pictureAttributeString' => $this->getPictureAttributeString(),
                 'src' => $asset->url(),
                 'srcSet' => '',
                 'srcSetWebp' => '',
@@ -97,6 +98,7 @@ class Responsive extends Tags
 
             return view('responsive-images::responsiveImageWithPlaceholder', [
                 'attributeString' => $this->getAttributeString(),
+                'pictureAttributeString' => $this->getPictureAttributeString(),
                 'src' => $asset->url(),
                 'srcSet' => $this->buildSrcSet($widths, $asset, $placeholder),
                 'srcSetWebp' => $includeWebp ? $this->buildSrcSet($widths, $asset, $placeholder, 'webp') : null,
@@ -108,6 +110,7 @@ class Responsive extends Tags
 
         return view('responsive-images::responsiveImage', [
             'attributeString' => $this->getAttributeString(),
+            'pictureAttributeString' => $this->getPictureAttributeString(),
             'src' => $asset->url(),
             'srcSet' => $this->buildSrcSet($widths, $asset),
             'srcSetWebp' => $includeWebp ? $this->buildSrcSet($widths, $asset, null, 'webp') : null,
@@ -141,10 +144,21 @@ class Responsive extends Tags
         return collect($this->params)
             ->except(['placeholder', 'webp', 'ratio'])
             ->reject(function ($value, $name) {
-                return Str::contains($name, 'glide:');
+                return Str::contains($name, ['glide:', 'picture:']);
             })
             ->map(function ($value, $name) {
                 return $name . '="' . $value . '"';
+            })->implode(' ');
+    }
+
+    private function getPictureAttributeString(): string
+    {
+        return collect($this->params)
+            ->filter(function ($value, $name) {
+                return Str::contains($name, 'picture:');
+            })
+            ->map(function ($value, $name) {
+                return str_replace('picture:', '', $name) . '="' . $value . '"';
             })->implode(' ');
     }
 


### PR DESCRIPTION
TL;DR These changes would allow passing attributes to the `picture` tag by prefixing attributes with `picture:`.

Sometimes it is necessary to style the picture tag, which is currently not possible using Tailwind CSS (the CSS Framework used by Statamic itself). While I understand that the goal is to keep this addon as simple as possible, I do think this should be core functionality. As far as I can tell publishing the views would not help, since the parameters would not get passed through ~and wrapping the picture tag in a styled div does not work for all instances~ (← could not reproduce).

Sticking with the notation used for the `glide` parameters, I decided to allow this by passing parameters prefixed with `picture:`. 