### PR TITLE
Prevent unnecessary sources in the <picture> element

### DIFF
--- a/src/Fieldtypes/ResponsiveFields.php
+++ b/src/Fieldtypes/ResponsiveFields.php
@@ -96,7 +96,7 @@ class ResponsiveFields
                                 ? __('Sets how the image is fitted to its target ratio.')
                                 : '',
                             'type' => 'select',
-                            'default' => 'crop_focal',
+                            'default' => $breakpoint === 'default' ? 'crop_focal' : null,
                             'options' => [
                                 'crop_focal' => __('Focal crop'),
                                 'contain' => __('Contain'),


### PR DESCRIPTION
The default behaviour of this addon is to output each breakpoint though the `srcset` might be identical to the lower breakpoint. This adds unnecessary bytes to the HTML response.

With the change of this PR only breakpoints with any filled input (src, ratio or fit) will be outputted.

This is accomplished by only setting a default value for the **Fit** input in the field type to the `default` breakpoint. The other breakpoints now use a *none* value just like the **Image** and **Ratio** inputs. This makes the "inheritance rule" consistent between all inputs.

The PR does not affect already stored entries until edited with an empty value. However, the change might result in unexpected behaviour to existing users because the breakpoint now uses the value of the previous breakpoint.

> Previous breakpoint’s choices will be used when empty.

Fixes #64