### PR TITLE
Fix issue with incorrect image sizes

### DIFF
--- a/resources/views/responsiveImage.blade.php
+++ b/resources/views/responsiveImage.blade.php
@@ -5,14 +5,14 @@
                 type="image/webp"
                 @isset($source['media']) media="{{ $source['media'] }}" @endisset
                 srcset="{{ $source['srcSetWebp'] }}"
-                @if($includePlaceholder ?? false) sizes="1px" @endif
+                @if($includePlaceholder ?? false) @endif
             >
         @endisset
 
         <source
             @isset($source['media']) media="{{ $source['media'] }}" @endisset
             srcset="{{ $source['srcSet'] }}"
-            @if($includePlaceholder ?? false) sizes="1px" @endif
+            @if($includePlaceholder ?? false) @endif
         >
     @endforeach
 
@@ -22,14 +22,6 @@
         @isset($width) width="{{ $width }}" @endisset
         @isset($height) height="{{ $height }}" @endisset
         @isset($sources)
-        onload="
-            this.onload=null;
-            var imgWidth = this.getBoundingClientRect().width;
-            this.parentNode.querySelectorAll('source')
-                .forEach(function (source) {
-                    source.sizes=Math.ceil(imgWidth/window.innerWidth*100)+'vw';
-                });
-        "
         @endisset
     >
 </picture>


### PR DESCRIPTION
Adding the size attribute is inadvertently breaking a few things. Whilst it's probably a good idea where you can accurately know the size of an image, it's not a thing we can know with plugin like this. I also know adding sizes is recommended in combination with a width descriptor, so rather than this PR you might want to add an option for users to turn this script on, but I've encountered so many times when the size calculations are wrong.

Firstly there is this issue https://github.com/spatie/statamic-responsive-images/issues/22 and this happens with device orientation switching, not to mention in demos when showing clients. I think you're too hasty to say this is a non issue. I encounter it daily and I know many non-developer audiences will encounter it too.

The 2nd time I commonly encounter this is with an image in a slideshow, or accordion or a similar dynamic component where the size of the image may change or really any case where the onload event fired and there is some change to the image.

The cost to removing this is not significant unless users are uploading super high-res images and not setting glide options to cap the generated sizes.