### PR TITLE
Small tweak to make the README read nicer on statamic.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
+<!-- statamic:hide -->
 [![Latest Version](https://img.shields.io/github/release/spatie/statamic-responsive-images.svg?style=flat-square)](https://github.com/spatie/statamic-responsive-images/releases)
 ![Statamic 3.0+](https://img.shields.io/badge/Statamic-3.0+-FF269E?style=flat-square&link=https://statamic.com)
 
 # Responsive Images
 
 > Responsive Images for Statamic 3.
+
+<!-- /statamic:hide -->
 
 This Addon provides responsive images inspired by [Our Medialibrary Package](https://github.com/spatie/laravel-medialibrary).
 


### PR DESCRIPTION
Everything between the special HTML comments `<!-- statamic:hide --><!-- /statamic:hide -->` is hidden on the product listing. 