### PR TITLE
Fixes spatie/statamic-responsive-images#82

### DIFF
--- a/src/Fieldtypes/ResponsiveFields.php
+++ b/src/Fieldtypes/ResponsiveFields.php
@@ -57,6 +57,7 @@ class ResponsiveFields
                         ? __('Choose an image to generate responsive versions from.')
                         : '',
                     'type' => 'assets',
+                    'localizable' => $this->config['localizable'],
                     'container' => $this->config['container'],
                     'folder' => $this->config['folder'] ?? '/',
                     'allow_uploads' => $this->config['allow_uploads'],


### PR DESCRIPTION
At the moment, the `localizable: true` does not work for the Responsive fieldtype. It shows `Read Only` when you are trying to localize the image in another language.

This MR provides a possibility to control the localization through `localizable: true/false` config just like most of the fieldtypes in Statamic.