### PR TITLE
Add Support for Statamic v3.3 / Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,11 @@
         }
     },
     "require": {
-        "statamic/cms": "~3.1|~3.2"
+        "statamic/cms": "3.3.*"
     },
+    "minimum-stability": "beta",
     "require-dev": {
-        "orchestra/testbench": "^6.9",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.5",
         "spatie/phpunit-snapshot-assertions": "^4.2",
         "spatie/laravel-ray": "^1.10"

--- a/src/Breakpoint.php
+++ b/src/Breakpoint.php
@@ -196,7 +196,7 @@ class Breakpoint implements Arrayable
 
             try {
                 $source = base64_encode($server->getCache()->read($path));
-                $base64Placeholder = "data:{$server->getCache()->getMimetype($path)};base64,{$source}";
+                $base64Placeholder = "data:{$server->getCache()->mimeType($path)};base64,{$source}";
             } catch (FileNotFoundException $e) {
                 return '';
             }

--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -65,6 +65,14 @@ class Responsive
             $asset = AssetFacade::findByUrl($assetParam['url']);
         }
 
+        if (is_string($asset)) {
+            $asset = AssetFacade::findByUrl($assetParam);
+
+            if (! $asset) {
+                $asset = AssetFacade::findByPath($assetParam);
+            }
+        }
+
         if (! isset($asset)) {
             throw AssetNotFoundException::create($assetParam);
         }

--- a/tests/Feature/ResponsiveTest.php
+++ b/tests/Feature/ResponsiveTest.php
@@ -94,6 +94,26 @@ class ResponsiveTest extends TestCase
         $this->assertEquals($this->asset->id(), $responsive->asset->id());
     }
 
+    /** @test */
+    public function it_can_initalize_using_a_string_value()
+    {
+        $value = new Value($this->asset->resolvedPath(), 'url');
+
+        $responsive = new Responsive($value, new Parameters());
+
+        $this->assertEquals($this->asset->id(), $responsive->asset->id());
+    }
+
+    /** @test */
+    public function it_can_initalize_using_a_string_url_value()
+    {
+        $value = new Value($this->asset->url(), 'url');
+
+        $responsive = new Responsive($value, new Parameters());
+
+        $this->assertEquals($this->asset->id(), $responsive->asset->id());
+    }
+
     /** @test * */
     public function it_can_initialize_using_values_from_the_fieldtype()
     {


### PR DESCRIPTION
This PR adds support for Statamic v3.3 (beta) and Laravel 9.
We've dropped support for prior Statamic/Laravel versions, as it would be easier to maintain one Flysystem implementation. :)

Statamic v3.3 is still in beta, so this shouldn't/can't be merged right now.

## TODOs

- [ ] Figure out a way to support both Laravel 8 and Laravel 9 (Flysystem changes)
- [ ] Update Actions Workflow
- [ ] Remove `minimum-stability` from composer.json once this gets merged
