### PR TITLE
Use setValue instead of fillValue

### DIFF
--- a/src/Fieldtypes/ResponsiveFieldtype.php
+++ b/src/Fieldtypes/ResponsiveFieldtype.php
@@ -212,7 +212,7 @@ class ResponsiveFieldtype extends Fieldtype
     {
         $fields = $this->fields()->all()->map(function (Field $field) use ($values) {
             return IlluminateArr::has($values, $field->handle())
-                ? $field->newInstance()->fillValue(IlluminateArr::get($values, $field->handle()))
+                ? $field->newInstance()->setValue(IlluminateArr::get($values, $field->handle()))
                 : $field->newInstance();
         });
 


### PR DESCRIPTION
This PR fixes #121.

In the latest version of Statamic (3.3.7) `Statamic\Fields\Field::fillValue()` has been removed, ref https://github.com/statamic/cms/commit/4b6dd3ccf6f46c5ac1fde4dc980af023bf01b81d#diff-22bb4c9ddfb67b736e92de38ac9fffc06904031c853cae90b1f35e270e04021eL249

In this PR `fillValue` is replaced with `setValue`.