### PR TITLE
Fix `method_exists` exception

### DIFF
--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -57,7 +57,7 @@ class Responsive
         if ($assetParam instanceof Value) {
             $asset = $assetParam->value();
 
-            if (method_exists($asset, 'first')) {
+            if (isset($asset) && method_exists($asset, 'first')) {
                 $asset = $asset->first();
             }
 


### PR DESCRIPTION
If the value of a `Value` object is `null`, the following error is thrown:

```
method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given
```

This happens if you've got an image field that is optional in the CP and don't wrap the `{{ responsive }}` tag in an if statement.

This PR fixes that issue by simply adding `isset()` along `method_exists()`.