### PR TITLE
Explicitly define crop focus

### DIFF
--- a/src/Breakpoint.php
+++ b/src/Breakpoint.php
@@ -4,6 +4,7 @@ namespace Spatie\ResponsiveImages;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
 use League\Flysystem\FileNotFoundException;
 use League\Glide\Server;
 use Spatie\ResponsiveImages\Jobs\GenerateImageJob;
@@ -82,7 +83,25 @@ class Breakpoint implements Arrayable
         unset($params['height']);
         unset($params['h']);
 
+        $crop = $this->getAssetCropFocus($params);
+
+        if ($crop) {
+            $params['fit'] = $crop;
+        }
+
         return $params;
+    }
+
+    private function getAssetCropFocus($params): string|null
+    {
+        if (
+            Config::get('statamic.assets.auto_crop') === false
+            || (array_key_exists('fit', $params) && $params['fit'] !== 'crop_focal')
+        ) {
+            return null;
+        }
+
+        return "crop-" . $this->asset->get('focus', '50-50');
     }
 
     /**

--- a/src/Breakpoint.php
+++ b/src/Breakpoint.php
@@ -83,7 +83,7 @@ class Breakpoint implements Arrayable
         unset($params['height']);
         unset($params['h']);
 
-        $crop = $this->getAssetCropFocus($params);
+        $crop = $this->getCropFocus($params);
 
         if ($crop) {
             $params['fit'] = $crop;
@@ -92,7 +92,7 @@ class Breakpoint implements Arrayable
         return $params;
     }
 
-    private function getAssetCropFocus($params): string|null
+    private function getCropFocus($params): string|null
     {
         if (
             Config::get('statamic.assets.auto_crop') === false

--- a/src/Responsive.php
+++ b/src/Responsive.php
@@ -114,7 +114,7 @@ class Responsive
                 foreach ($parameters as $parameter) {
                     if ($parameter['key'] === 'src' && ! $parameter['value'] instanceof Asset) {
                         try {
-                            $parameter['value'] = $this->retrieveAsset($parameter['value']);
+                            $parameter['value'] = $this->retrieveAsset($parameter['value'])->hydrate();
                         } catch (AssetNotFoundException $e) {
                             logger()->error($e->getMessage());
                             $parameter['value'] = $this->asset;

--- a/tests/Feature/BreakpointTest.php
+++ b/tests/Feature/BreakpointTest.php
@@ -32,7 +32,7 @@ class BreakpointTest extends TestCase
         $responsive = new Breakpoint($this->asset, 'default', 0, []);
 
         $this->assertStringContainsString(
-            '?q=90&w=100',
+            '?q=90&fit=crop-50-50&w=100',
             $responsive->buildImageJob(100)->handle()
         );
     }
@@ -43,7 +43,7 @@ class BreakpointTest extends TestCase
         $responsive = new Breakpoint($this->asset, 'default', 0, []);
 
         $this->assertStringContainsString(
-            '?fm=webp&q=90&w=100',
+            '?fm=webp&q=90&fit=crop-50-50&w=100',
             $responsive->buildImageJob(100, 'webp')->handle()
         );
     }
@@ -54,7 +54,7 @@ class BreakpointTest extends TestCase
         $responsive = new Breakpoint($this->asset, 'default', 0, []);
 
         $this->assertStringContainsString(
-            '?fm=webp&q=90&w=100&h=100',
+            '?fm=webp&q=90&fit=crop-50-50&w=100&h=100',
             $responsive->buildImageJob(100, 'webp', 1.0)->handle()
         );
     }

--- a/tests/Feature/BreakpointTest.php
+++ b/tests/Feature/BreakpointTest.php
@@ -70,4 +70,28 @@ class BreakpointTest extends TestCase
 
         $breakpoint->getSrcSet();
     }
+
+    /** @test * */
+    public function it_does_not_generate_image_url_with_crop_focus_when_auto_crop_is_disabled()
+    {
+        config()->set('statamic.assets.auto_crop', false);
+
+        $breakpoint = new Breakpoint($this->asset, 'default', 0, []);
+
+        $this->assertStringEndsWith(
+            '?fm=webp&q=90&w=100&h=100',
+            $breakpoint->buildImageJob(100, 'webp', 1.0)->handle()
+        );
+    }
+
+    /** @test * */
+    public function it_does_not_generate_image_url_with_crop_focus_when_a_glide_fit_param_is_provided()
+    {
+        $breakpoint = new Breakpoint($this->asset, 'default', 0, ['glide:fit' => 'fill']);
+
+        $this->assertStringEndsWith(
+            '?fit=fill&fm=webp&q=90&w=100&h=100',
+            $breakpoint->buildImageJob(100, 'webp', 1.0)->handle()
+        );
+    }
 }

--- a/tests/Feature/__snapshots__/GraphQLTest__graphql_asset_outputs_avif_srcset_when_enabled_through_arguments__1.json
+++ b/tests/Feature/__snapshots__/GraphQLTest__graphql_asset_outputs_avif_srcset_when_enabled_through_arguments__1.json
@@ -3,7 +3,7 @@
         "asset": {
             "responsive": [
                 {
-                    "srcSetAvif": "\/img\/asset\/dGVzdF9jb250YWluZXIvZ3JhcGhxbC5qcGc=?fm=avif&q=45&w=237&h=195.17647058824 237w, \/img\/asset\/dGVzdF9jb250YWluZXIvZ3JhcGhxbC5qcGc=?fm=avif&q=45&w=284&h=233.88235294118 284w, \/img\/asset\/dGVzdF9jb250YWluZXIvZ3JhcGhxbC5qcGc=?fm=avif&q=45&w=340&h=280 340w"
+                    "srcSetAvif": "\/img\/asset\/dGVzdF9jb250YWluZXIvZ3JhcGhxbC5qcGc=?fm=avif&q=45&fit=crop-50-50&w=237&h=195.17647058824 237w, \/img\/asset\/dGVzdF9jb250YWluZXIvZ3JhcGhxbC5qcGc=?fm=avif&q=45&fit=crop-50-50&w=284&h=233.88235294118 284w, \/img\/asset\/dGVzdF9jb250YWluZXIvZ3JhcGhxbC5qcGc=?fm=avif&q=45&fit=crop-50-50&w=340&h=280 340w"
                 }
             ]
         }

--- a/tests/Feature/__snapshots__/GraphQLTest__graphql_asset_outputs_avif_srcset_when_enabled_through_config__1.json
+++ b/tests/Feature/__snapshots__/GraphQLTest__graphql_asset_outputs_avif_srcset_when_enabled_through_config__1.json
@@ -3,7 +3,7 @@
         "asset": {
             "responsive": [
                 {
-                    "srcSetAvif": "\/img\/asset\/dGVzdF9jb250YWluZXIvZ3JhcGhxbC5qcGc=?fm=avif&q=45&w=237&h=195.17647058824 237w, \/img\/asset\/dGVzdF9jb250YWluZXIvZ3JhcGhxbC5qcGc=?fm=avif&q=45&w=284&h=233.88235294118 284w, \/img\/asset\/dGVzdF9jb250YWluZXIvZ3JhcGhxbC5qcGc=?fm=avif&q=45&w=340&h=280 340w"
+                    "srcSetAvif": "\/img\/asset\/dGVzdF9jb250YWluZXIvZ3JhcGhxbC5qcGc=?fm=avif&q=45&fit=crop-50-50&w=237&h=195.17647058824 237w, \/img\/asset\/dGVzdF9jb250YWluZXIvZ3JhcGhxbC5qcGc=?fm=avif&q=45&fit=crop-50-50&w=284&h=233.88235294118 284w, \/img\/asset\/dGVzdF9jb250YWluZXIvZ3JhcGhxbC5qcGc=?fm=avif&q=45&fit=crop-50-50&w=340&h=280 340w"
                 }
             ]
         }

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__a_glide_width_parameter_counts_as_max_width__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__a_glide_width_parameter_counts_as_max_width__1.txt
@@ -19,11 +19,11 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;fm=webp&amp;q=90&amp;h=41.176470588235 50w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;fm=webp&amp;q=90&amp;fit=crop-50-50&amp;h=41.176470588235 50w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;q=90&amp;h=41.176470588235 50w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;q=90&amp;fit=crop-50-50&amp;h=41.176470588235 50w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__format_quality_is_set_on_breakpoints__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__format_quality_is_set_on_breakpoints__1.txt
@@ -19,15 +19,15 @@
 <picture>
                     
         <source
-             media="(min-width: 1024px)"             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=70&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=70&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=70&amp;w=340&amp;h=280 340w"
+             media="(min-width: 1024px)"             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=70&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=70&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=70&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
                     
         <source
-             media="(min-width: 768px)"             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=50&amp;w=340&amp;h=280 340w"
+             media="(min-width: 768px)"             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=50&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=50&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=50&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
                     
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=30&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=30&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=30&amp;w=340&amp;h=280 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=30&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=30&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=30&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_adds_custom_parameters_to_the_attribute_string__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_adds_custom_parameters_to_the_attribute_string__1.txt
@@ -19,11 +19,11 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=280 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=280 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_can_add_custom_glide_parameters__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_can_add_custom_glide_parameters__1.txt
@@ -19,11 +19,11 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?blur=10&amp;fm=webp&amp;q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?blur=10&amp;fm=webp&amp;q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?blur=10&amp;fm=webp&amp;q=90&amp;w=340&amp;h=280 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?blur=10&amp;fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?blur=10&amp;fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?blur=10&amp;fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?blur=10&amp;q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?blur=10&amp;q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?blur=10&amp;q=90&amp;w=340&amp;h=280 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?blur=10&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?blur=10&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?blur=10&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_can_render_a_responsive_image_with_the_directive__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_can_render_a_responsive_image_with_the_directive__1.txt
@@ -19,11 +19,11 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=280 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=280 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_can_render_an_art_directed_image_as_array_with_the_directive__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_can_render_an_art_directed_image_as_array_with_the_directive__1.txt
@@ -19,11 +19,11 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=280 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=280 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_can_render_an_art_directed_image_with_the_directive__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_can_render_an_art_directed_image_with_the_directive__1.txt
@@ -19,11 +19,11 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=280 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=280 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images__1.txt
@@ -19,11 +19,11 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=280 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=280 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_in_webp_and_avif_formats__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_in_webp_and_avif_formats__1.txt
@@ -19,15 +19,15 @@
 <picture>
                         <source
                 type="image/avif"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=avif&amp;q=45&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=avif&amp;q=45&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=avif&amp;q=45&amp;w=340&amp;h=280 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=avif&amp;q=45&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=avif&amp;q=45&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=avif&amp;q=45&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                  sizes="1px"             >
                             <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=280 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=280 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_in_webp_and_avif_formats__2.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_in_webp_and_avif_formats__2.txt
@@ -19,15 +19,15 @@
 <picture>
                         <source
                 type="image/avif"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=avif&amp;q=45&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=avif&amp;q=45&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=avif&amp;q=45&amp;w=340&amp;h=280 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=avif&amp;q=45&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=avif&amp;q=45&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=avif&amp;q=45&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                  sizes="1px"             >
                             <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=280 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=280 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_with_breakpoint_parameters__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_with_breakpoint_parameters__1.txt
@@ -19,19 +19,19 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media="(min-width: 1024px)"                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=158 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=189.33333333333 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=226.66666666667 340w"
+                 media="(min-width: 1024px)"                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=158 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=189.33333333333 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=226.66666666667 340w"
                  sizes="1px"             >
         
         <source
-             media="(min-width: 1024px)"             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=158 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=189.33333333333 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=226.66666666667 340w"
+             media="(min-width: 1024px)"             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=158 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=189.33333333333 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=226.66666666667 340w"
              sizes="1px"         >
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=340 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=340 340w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=340 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=340 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_with_breakpoints_without_webp__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_with_breakpoints_without_webp__1.txt
@@ -19,11 +19,11 @@
 <picture>
                     
         <source
-             media="(min-width: 1024px)"             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=340 340w"
+             media="(min-width: 1024px)"             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=340 340w"
              sizes="1px"         >
                     
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=280 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_with_parameters__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_with_parameters__1.txt
@@ -19,11 +19,11 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=340 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=340 340w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=340 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=340 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_without_a_placeholder__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_without_a_placeholder__1.txt
@@ -19,11 +19,11 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media=""                 srcset="/img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=280 340w"
+                 media=""                 srcset="/img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                             >
         
         <source
-             media=""             srcset="/img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=280 340w"
+             media=""             srcset="/img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                     >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_without_webp__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_generates_responsive_images_without_webp__1.txt
@@ -19,7 +19,7 @@
 <picture>
                     
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=280 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__it_uses_an_alt_field_on_the_asset__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__it_uses_an_alt_field_on_the_asset__1.txt
@@ -19,11 +19,11 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=280 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=280 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=195.17647058824 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=233.88235294118 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=280 340w"
              sizes="1px"         >
     
     <img

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__the_source_image_can_change_with_breakpoints__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__the_source_image_can_change_with_breakpoints__1.txt
@@ -19,19 +19,19 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media="(min-width: 1024px)"                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdDIuanBn?fm=webp&amp;q=90&amp;w=237&amp;h=158 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdDIuanBn?fm=webp&amp;q=90&amp;w=284&amp;h=189.33333333333 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdDIuanBn?fm=webp&amp;q=90&amp;w=340&amp;h=226.66666666667 340w"
+                 media="(min-width: 1024px)"                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdDIuanBn?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=158 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdDIuanBn?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=189.33333333333 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdDIuanBn?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=226.66666666667 340w"
                  sizes="1px"             >
         
         <source
-             media="(min-width: 1024px)"             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdDIuanBn?q=90&amp;w=237&amp;h=158 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdDIuanBn?q=90&amp;w=284&amp;h=189.33333333333 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdDIuanBn?q=90&amp;w=340&amp;h=226.66666666667 340w"
+             media="(min-width: 1024px)"             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdDIuanBn?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=158 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdDIuanBn?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=189.33333333333 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdDIuanBn?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=226.66666666667 340w"
              sizes="1px"         >
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;w=340&amp;h=340 340w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?fm=webp&amp;q=90&amp;fit=crop-50-50&amp;w=340&amp;h=340 340w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;w=340&amp;h=340 340w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=237&amp;h=237 237w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=284&amp;h=284 284w, /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?q=90&amp;fit=crop-50-50&amp;w=340&amp;h=340 340w"
              sizes="1px"         >
     
     <img


### PR DESCRIPTION
Fixes #126.

I will file a bug report to `statamic/cms` repo too but meanwhile I think it does not hurt to generate URLs that explicitly define the crop focus. I think this is normal default behavior for images to be crop focused on this addon, if not they can override with `glide:fit` param or the `statamic.assets.auto_crop` config if they have not already.

I will ping you Rias once the PR is marked ready. :)