### PR TITLE
Prevent float to int conversion warning

### DIFF
--- a/src/WidthCalculator.php
+++ b/src/WidthCalculator.php
@@ -47,7 +47,7 @@ class WidthCalculator
         }
     }
 
-    protected function finishedCalculating(int $predictedFileSize, int $newWidth): bool
+    protected function finishedCalculating(float $predictedFileSize, int $newWidth): bool
     {
         if ($newWidth < 20) {
             return true;


### PR DESCRIPTION
The $predictedFileSize on line 32 provides a float instead of an integer, in that case we can change the parameter type declaration to float to prevent the Implicit conversion from float to int loses precision warning.