### PR TITLE
Fix fieldtype Vue component issues

### DIFF
--- a/resources/js/ResponsiveFieldtype.vue
+++ b/resources/js/ResponsiveFieldtype.vue
@@ -24,6 +24,7 @@
 
 export default {
   mixins: [Fieldtype],
+
   computed: {
     fields() {
       return _.chain(this.meta.fields)

--- a/resources/js/ResponsiveFieldtype.vue
+++ b/resources/js/ResponsiveFieldtype.vue
@@ -5,6 +5,7 @@
         :values="value"
         :meta="meta"
         :errors="errors"
+        :trackDirtyState="false"
         @updated="updated($event)"
     >
       <div slot-scope="{ setFieldValue, setFieldMeta }">
@@ -23,7 +24,6 @@
 
 export default {
   mixins: [Fieldtype],
-
   computed: {
     fields() {
       return _.chain(this.meta.fields)
@@ -57,7 +57,6 @@ export default {
   methods: {
     updated(data) {
       const value = Object.assign({}, data);
-      this.value = value;
       this.update(value);
     },
   },


### PR DESCRIPTION
From what I found, setting `this.value = value;` seems redundant and the value updates, saves correctly with just `this.update(value);`. Removing this line fixes the warning #155 

Adding `:trackDirtyState="false"` fixes the dirty state part of the #120 issue. The issue was if you were to save an entry with "Go to listing" save option, it would unnecessarily, annoyingly trigger the "Reload site?" prompt. The dirty state tracking still works as this `ResponsiveFieldtype` component is a child of another `PublishContainer` component which already has dirty state tracking. I assume wherever this `ResponsiveFieldtype` might appear, a parent component `PublishContainer` has dirty state tracking anyway.