### PR TITLE
Fix required validation not requiring asset

### DIFF
--- a/src/Fieldtypes/ResponsiveFields.php
+++ b/src/Fieldtypes/ResponsiveFields.php
@@ -74,7 +74,7 @@ class ResponsiveFields
                     'width' => $this->config['use_breakpoints']
                         ? ($this->config['allow_ratio'] ? ($this->config['allow_fit'] ? 25 : 33) : 66)
                         : ($this->config['allow_ratio'] ? ($this->config['allow_fit'] ? 50 : 66) : 100),
-                    'required' => in_array('required', $this->validate ?? []) && $index === 0,
+                    'required' => in_array('required', $this->config['validate'] ?? []) && $index === 0,
                     'validate' => [new ImageRule()],
                 ],
             ];


### PR DESCRIPTION
I am not sure if `$this->validate` ever was available. This seems like a mistake I think, as `ResponsiveFields` class does not appear to be a special class that may get properties auto injected, it only gets a `config` property, I do not see a `validate` property in `ResponsiveFields`. :sweat_smile: 

Partially addresses #163.
Fixes #120.