### PR TITLE
Fix `src` saving as an array and not as string

### DIFF
--- a/src/Fieldtypes/ResponsiveFieldtype.php
+++ b/src/Fieldtypes/ResponsiveFieldtype.php
@@ -178,7 +178,7 @@ class ResponsiveFieldtype extends Fieldtype
         }
 
         return Arr::removeNullValues(
-            $this->getFieldsWithValues($data)->preProcess()->values()->all()
+            $this->getFieldsWithValues($data)->process()->values()->all()
         );
     }
 


### PR DESCRIPTION
Fixes #172.

As far as I understood, `process` method on fieldtypes is used for when field is being saved, and `preProcess` is for displaying the field. In `ResponsiveFieldtype@process` we are calling `preProcess` for all fields, when it should be just `process`. We are saving data there, not displaying.

Code from [Assets fieldtype](https://github.com/statamic/cms/blob/3.3/src/Fieldtypes/Assets/Assets.php).

```php
public function preProcess($values)
{
    if (is_null($values)) {
        return [];
    }

    return collect($values)->map(function ($value) {
        return $this->valueToId($value);
    })->filter()->values()->all();
}
```

```php
public function process($data)
{
    $max_files = (int) $this->config('max_files');

    $values = collect($data)->map(function ($id) {
        return Asset::find($id)->path();
    });

    return $this->config('max_files') === 1 ? $values->first() : $values->all();
}
```

As you can see, core `Assets` fieldtype handles `max_files` being `1` only when saving. When `preProcessing` or displaying the data, it uses collection/array.

I am guessing you are not suppose to mix and match `process` and `preProcess` together in either one.