### PR TITLE
Force tag width & height parameters to a whole number

### DIFF
--- a/src/Tags/ResponsiveTag.php
+++ b/src/Tags/ResponsiveTag.php
@@ -85,8 +85,8 @@ class ResponsiveTag extends Tags
             'placeholder' => $sources->last()['placeholder'],
             'src' => $src,
             'sources' => $sources,
-            'width' => $width,
-            'height' => $height,
+            'width' => round($width),
+            'height' => round($height),
             'asset' => $responsive->asset->toAugmentedArray(),
         ])->render();
     }

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__a_glide_width_parameter_counts_as_max_width__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__a_glide_width_parameter_counts_as_max_width__1.txt
@@ -19,16 +19,16 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;fm=webp&amp;q=90&amp;fit=crop-50-50&amp;h=41 50w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;fm=webp&amp;q=90&amp;fit=crop-50-50&amp;h=41.176470588235 50w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;q=90&amp;fit=crop-50-50&amp;h=41 50w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;q=90&amp;fit=crop-50-50&amp;h=41.176470588235 50w"
              sizes="1px"         >
     
     <img
         
-        src="/img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;h=41"
+        src="/img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;h=41.176470588235"
                 alt="test.jpg"
                  width="50"          height="41"                 data-statamic-responsive-images
             >

--- a/tests/Feature/__snapshots__/ResponsiveTagTest__a_glide_width_parameter_counts_as_max_width__1.txt
+++ b/tests/Feature/__snapshots__/ResponsiveTagTest__a_glide_width_parameter_counts_as_max_width__1.txt
@@ -19,17 +19,17 @@
 <picture>
                                 <source
                 type="image/webp"
-                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;fm=webp&amp;q=90&amp;fit=crop-50-50&amp;h=41.176470588235 50w"
+                 media=""                 srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;fm=webp&amp;q=90&amp;fit=crop-50-50&amp;h=41 50w"
                  sizes="1px"             >
         
         <source
-             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;q=90&amp;fit=crop-50-50&amp;h=41.176470588235 50w"
+             media=""             srcset=", /img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;q=90&amp;fit=crop-50-50&amp;h=41 50w"
              sizes="1px"         >
     
     <img
         
-        src="/img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;h=41.176470588235"
+        src="/img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=?w=50&amp;h=41"
                 alt="test.jpg"
-                 width="50"          height="41.176470588235"                 data-statamic-responsive-images
+                 width="50"          height="41"                 data-statamic-responsive-images
             >
 </picture>


### PR DESCRIPTION
It is probably a rare occurance, but I have had a number of times where the combination of image dimensions & the ratio I've selected have resulted in a decimal number in the output of the responsive tags, which isnt valid html. This PR would just make sure that the output of those parameters are always whole numbers. 