### PR TITLE
Account for broken images when generating placeholders

### DIFF
--- a/src/Breakpoint.php
+++ b/src/Breakpoint.php
@@ -5,6 +5,7 @@ namespace Spatie\ResponsiveImages;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use League\Flysystem\FilesystemException;
 use Spatie\ResponsiveImages\Jobs\GenerateImageJob;
 use Statamic\Contracts\Assets\Asset;
 use Statamic\Facades\Blink;
@@ -294,7 +295,7 @@ class Breakpoint implements Arrayable
         try {
             $assetContent = $cache->read($assetPath);
             $assetMimeType = $cache->mimeType($assetPath);
-        } catch (\Exception $e) {
+        } catch (FilesystemException $e) {
             if (config('app.debug')) {
                 throw $e;
             }

--- a/src/Breakpoint.php
+++ b/src/Breakpoint.php
@@ -266,8 +266,16 @@ class Breakpoint implements Arrayable
              * @see \Statamic\Tags\Glide::generateGlideDataUrl
              */
             $cache = GlideManager::cacheDisk();
-            $assetContentEncoded = base64_encode($cache->read($manipulationPath));
-            $base64Placeholder = 'data:'.$cache->mimeType($manipulationPath).';base64,'.$assetContentEncoded;
+
+            try {
+                $assetContent = $cache->read($manipulationPath);
+            } catch (\Exception $e) {
+                logger()->error($e->getMessage());
+
+                $assetContent = '';
+            }
+
+            $base64Placeholder = 'data:'.$cache->mimeType($manipulationPath).';base64,'.base64_encode($assetContent);
 
             return view('responsive-images::placeholderSvg', [
                 'width' => 32,

--- a/src/Breakpoint.php
+++ b/src/Breakpoint.php
@@ -305,6 +305,6 @@ class Breakpoint implements Arrayable
             return null;
         }
 
-        return 'data:'.$cache->mimeType($assetPath).';base64,'.base64_encode($assetContent);
+        return 'data:' . $assetMimeType . ';base64,' . base64_encode($assetContent);
     }
 }

--- a/tests/Feature/BreakpointTest.php
+++ b/tests/Feature/BreakpointTest.php
@@ -122,7 +122,7 @@ it('generates placeholder data url when toggling cache form on to off', function
     /**
      * We use Blink cache for placeholder generation that we need to clear just in case
      * @see https://statamic.dev/extending/blink-cache
-     * @see Breakpoint::placeholderSvg()
+     * @see Breakpoint::placeholder()
      */
     Blink::store()->flush();
 

--- a/tests/Feature/BreakpointTest.php
+++ b/tests/Feature/BreakpointTest.php
@@ -141,3 +141,20 @@ it('generates placeholder data url when toggling cache form on to off', function
     expect($secondPlaceholder)->toEqual($firstPlaceholder)
         ->and($cacheDiskPathAfter)->not->toEqual($cacheDiskPathBefore);
 });
+
+it("doesn't crash when the placeholder image cannot be read", function () {
+    $responsive = new Breakpoint($this->asset, 'default', 0, []);
+
+    // Generate placeholder to trigger caching
+    $responsive->placeholder();
+
+    // Forget cached files
+    $pathPrefix = \Statamic\Imaging\ImageGenerator::assetCachePathPrefix($this->asset);
+
+    \Statamic\Facades\Glide::server()->deleteCache($pathPrefix.'/'.$this->asset->path());
+
+    Blink::store()->flush();
+
+    // Generate new placeholder
+    $responsive->placeholder();
+})->expectNotToPerformAssertions();


### PR DESCRIPTION
Very rarely it happens that images in the Glide cache cannot be read correctly. In this case the read method of Flysystem throws an `UnableToReadFile` exception.

This can break the whole website, because the Responsive Images addon uses the read method to generate placeholders without further checking:

https://github.com/spatie/statamic-responsive-images/blob/v2.14.4/src/Breakpoint.php#L269

A broken website can be reproduced like this:

- Install Responsive Images addon (default settings)
- Upload an image
- Use the 'responsive' tag your antlers template to output the image
- Open the website
- Delete/rename cached images in the filesystem (storage/statamic/glide/containers/...)
- Open the website again

The situation that an image in the cache cannot be read _should_ not actually occur. However, we already had this case twice.

Therefore, I suggest using the read method in a try catch statement. As it is suggested in the Flysystem docs:

https://flysystem.thephpleague.com/docs/usage/filesystem-api/#filesystemreaderread

To be clear, this PR does not automatically rebuild broken image caches. This should be tackled by Statamic itself. But after the modification, the entire website is no longer broken. Only the affected image.