### PR TITLE
Fix failing tests due to source asset being deleted once uploaded

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,8 +12,7 @@ jobs:
         php: [8.0, 8.1]
         statamic: [3.3.*, 3.4.*]
         include:
-          - statamic: 3.3.*
-            testbench: 7.*
+          - testbench: 7.*
     
     name: PHP ${{ matrix.php }} - Statamic ${{ matrix.statamic }}
     

--- a/tests/Feature/ResponsiveTagTest.php
+++ b/tests/Feature/ResponsiveTagTest.php
@@ -19,27 +19,15 @@ function assertMatchesSnapshotWithoutSvg($value)
 }
 
 beforeEach(function () {
-    $file = new UploadedFile($this->getTestJpg(), 'test.jpg');
-    $path = ltrim('/' . $file->getClientOriginalName(), '/');
-    $this->asset = $this->assetContainer->makeAsset($path)->upload($file);
-
-    $file2 = new UploadedFile($this->getTestJpg(), 'test2.jpg');
-    $path = ltrim('/' . $file2->getClientOriginalName(), '/');
-    $this->asset2 = $this->assetContainer->makeAsset($path)->upload($file2);
-
-    $svg = new UploadedFile($this->getTestSvg(), 'test.svg');
-    $path = ltrim('/' . $file->getClientOriginalName(), '/');
-    $this->svgAsset = $this->assetContainer->makeAsset($path)->upload($svg);
-
-    $gif = new UploadedFile($this->getTestGif(), 'hackerman.gif');
-    $path = ltrim('/' . $file->getClientOriginalName(), '/');
-    $this->gifAsset = $this->assetContainer->makeAsset($path)->upload($gif);
-
+    $this->asset = $this->uploadTestImageToTestContainer();
+    $this->asset2 = $this->uploadTestImageToTestContainer($this->getTestJpg(), 'test2.jpg');
+    $this->svgAsset = $this->uploadTestImageToTestContainer($this->getTestSvg(), 'test.svg');
+    $this->gifAsset = $this->uploadTestImageToTestContainer($this->getTestGif(), 'hackerman.gif');
     Stache::clear();
 });
 
 it('generates responsive images')
-    ->tap(fn () =>  assertMatchesSnapshotWithoutSvg(ResponsiveTag::render($this->asset)));
+    ->tap(fn () => assertMatchesSnapshotWithoutSvg(ResponsiveTag::render($this->asset)));
 
 it('generates no conversions for svgs')
     ->tap(fn () => assertMatchesSnapshotWithoutSvg(ResponsiveTag::render($this->svgAsset)));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,8 @@
 namespace Spatie\ResponsiveImages\Tests;
 
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
@@ -165,5 +167,20 @@ class TestCase extends OrchestraTestCase
     public function getTestGif(): string
     {
         return $this->getTestFilesDirectory('hackerman.gif');
+    }
+
+    public function uploadTestImageToTestContainer(?string $testImagePath = null, ?string $filename = 'test.jpg')
+    {
+        if ($testImagePath === null) {
+            $testImagePath = test()->getTestJpg();
+        }
+
+        // Duplicate file because in Statamic 3.4 the source asset is deleted after upload
+        $duplicateImagePath = preg_replace('/(\.[^.]+)$/', '-' . Carbon::now()->timestamp . '$1', $testImagePath);
+        File::copy($testImagePath, $duplicateImagePath);
+
+        $file = new UploadedFile($duplicateImagePath, $filename);
+        $path = ltrim('/' . $file->getClientOriginalName(), '/');
+        return $this->assetContainer->makeAsset($path)->upload($file);
     }
 }


### PR DESCRIPTION
Breaking change (sort of) introduced in 3.4, so we workaround by duplicating the source file