### PR TITLE
Configurable class for DimensionCalculator

### DIFF
--- a/config/responsive-images.php
+++ b/config/responsive-images.php
@@ -129,5 +129,16 @@ return [
     */
 
     'breakpoint_unit' => 'px',
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Dimension Calculator Class
+    |--------------------------------------------------------------------------
+    |
+    | The class that will be used for the breakpoint srcset calculations
+    |
+    */
+    
+    'dimension_calculator' => \Spatie\ResponsiveImages\ResponsiveDimensionCalculator::class,
 
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -106,7 +106,7 @@ class ServiceProvider extends AddonServiceProvider
 
     private function bindDimensionCalculator(): self
     {
-        $this->app->bind(DimensionCalculator::class, ResponsiveDimensionCalculator::class);
+        $this->app->bind(DimensionCalculator::class, config('statamic.responsive-images.dimension_calculator'));
 
         return $this;
     }


### PR DESCRIPTION
Hi, for some reason I've not been able to override `DimensionCalculator::class` using the example in the recently merged pull request #193 in my `AppServiceProvider.php` file (maybe the package boot binding order prevents this?) so this pull request changes its binding to use a configurable class, similar to how [Spatie Media Library](https://github.com/spatie/laravel-medialibrary/blob/0d2074ac07ebf0913359e987faf742c71a975832/src/MediaLibraryServiceProvider.php) does it.
I was then able to override it with a custom class configurable in `config/responsive-images.php` eg:
```php
    /*
    |--------------------------------------------------------------------------
    | Dimension Calculator Class
    |--------------------------------------------------------------------------
    |
    | The class that will be used for the breakpoint srcset calculations
    |
    */

    'dimension_calculator' => \App\Media\MyDimensionCalculator::class,
```