### PR TITLE
Cast image string to array with src attribute

### DIFF
--- a/src/Fieldtypes/ResponsiveFieldtype.php
+++ b/src/Fieldtypes/ResponsiveFieldtype.php
@@ -137,6 +137,11 @@ class ResponsiveFieldtype extends Fieldtype
 
     public function preProcess($data)
     {
+        if (!is_array($data)) {
+            $data = [
+                'src' => $data,
+            ];
+        }
         return $this->getFieldsWithValues($data)->preProcess()->values()->all();
     }
 


### PR DESCRIPTION
This is a minor change to allow for easier migration from Statamic's built in asset fieldtype to the responsive fieldtype provided by this addon. 

It allows us to simply change the type of an asset field (with limit 1) to responsive and automatically import the existing image as the default image in the responsive set, instead of having to go through and manually changing the data everywhere.