### PR TITLE
Add a config variable to the srcset generation multiplier

### DIFF
--- a/config/responsive-images.php
+++ b/config/responsive-images.php
@@ -130,4 +130,16 @@ return [
 
     'breakpoint_unit' => 'px',
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Srcset dimensions multiplier
+    |--------------------------------------------------------------------------
+    |
+    | When generating the srcset for an image, this value will be used to calculate the different sizes.
+    |
+    */
+
+    'srcset_dimensions_multiplier' => 0.7,
+
 ];

--- a/src/ResponsiveDimensionCalculator.php
+++ b/src/ResponsiveDimensionCalculator.php
@@ -77,7 +77,7 @@ class ResponsiveDimensionCalculator implements DimensionCalculator
         $pixelPrice = $predictedFileSize / $area;
 
         while (true) {
-            $predictedFileSize *= config('statamic.responsive-images.predicted_file_size_multiplier', 0.7);
+            $predictedFileSize *= config('statamic.responsive-images.srcset_dimensions_multiplier', 0.7);
 
             $newWidth = (int) floor(sqrt(($predictedFileSize / $pixelPrice) / $ratioForFilesize));
 

--- a/src/ResponsiveDimensionCalculator.php
+++ b/src/ResponsiveDimensionCalculator.php
@@ -77,7 +77,7 @@ class ResponsiveDimensionCalculator implements DimensionCalculator
         $pixelPrice = $predictedFileSize / $area;
 
         while (true) {
-            $predictedFileSize *= 0.7;
+            $predictedFileSize *= config('statamic.responsive-images.predicted_file_size_multiplier', 0.7);
 
             $newWidth = (int) floor(sqrt(($predictedFileSize / $pixelPrice) / $ratioForFilesize));
 


### PR DESCRIPTION
When using this package, I believe it sometimes generates too many variants in the srcset tag. By simply allowing us to change the size multiplier, one can alter this behavior to their liking.

Feel free to change any of the config names if there's something more suitable.