### PR TITLE
v5 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2]
-        statamic: [4.0.*, v5.0.0-beta.2 as v5.0.0]
+        php: [8.1, 8.2, 8.3]
+        statamic: [v5.0.0-beta.2 as v5.0.0]
         include:
           - testbench: 7.*
     

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         php: [8.0, 8.1, 8.2]
-        statamic: [4.0.*]
+        statamic: [4.0.*, v5.0.0-beta.2 as v5.0.0]
         include:
           - testbench: 7.*
     

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
         php: [8.1, 8.2, 8.3]
         statamic: [v5.0.0-beta.2 as v5.0.0]
         include:
-          - testbench: 7.*
+          - testbench: 8.*
     
     name: PHP ${{ matrix.php }} - Statamic ${{ matrix.statamic }}
     

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
         }
     },
     "require": {
-        "statamic/cms": "^4.0"
+        "statamic/cms": "v5.0.0-beta.2 as v5.0.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.9|^7.1",
+        "orchestra/testbench": "^6.9|^7.1|^8.0|^9.0",
         "pestphp/pest": "^1.22",
         "spatie/pest-plugin-snapshots": "^1.1"
     },

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -94,8 +94,15 @@ class TestCase extends OrchestraTestCase
         parent::resolveApplicationConfiguration($app);
 
         $configs = [
-            'assets', 'cp', 'forms', 'routes', 'static_caching',
-            'sites', 'stache', 'system', 'users',
+            'assets',
+            'cp',
+            'forms',
+            'routes',
+            'static_caching',
+            // 'sites',
+            'stache',
+            'system',
+            'users',
         ];
 
         foreach ($configs as $config) {


### PR DESCRIPTION
WIP

Problems found:
- Multisites config has been moved
- Glide now always outputs URLs with original filename https://github.com/statamic/cms/pull/9616
- Missing alt attribute string

Things to check:
- Glide hash https://github.com/statamic/cms/pull/9918
- https://github.com/statamic/cms/pull/9871
- https://github.com/statamic/cms/pull/9573

Things to check from v4:
- https://github.com/statamic/cms/pull/9378
- https://github.com/statamic/cms/pull/9109

v5.0 cms upgrade guide for reference: https://github.com/statamic/docs/pull/1311/files

Supported things would be the same as Statamic core package:
- PHP 8.1, 8.2, 8.3
- Laravel 10, 11
- Statamic 5
