### PR TITLE
Apply glide params to src image

### DIFF
--- a/src/Tags/ResponsiveTag.php
+++ b/src/Tags/ResponsiveTag.php
@@ -59,10 +59,10 @@ class ResponsiveTag extends Tags
         $width = $dimensions->getWidth();
         $height = $dimensions->getHeight();
 
-        $src = app(GenerateImageJob::class, ['asset' => $responsive->asset, 'params' => [
-            'width' => $width,
-            'height' => $height,
-        ]])->handle();
+        $src = app(GenerateImageJob::class, [
+            'asset' => $responsive->asset,
+            'params' => array_merge($this->getGlideParams(), ['width' => $width, 'height' => $height]),
+        ])->handle();
 
         $includePlaceholder = $this->includePlaceholder();
 
@@ -80,6 +80,14 @@ class ResponsiveTag extends Tags
                 return $breakpoint->sources();
             })->flatten()->count() > 0,
         ])->render();
+    }
+
+    private function getGlideParams(): array
+    {
+        return collect($this->params)
+            ->reject(fn ($value, $name) => ! str_starts_with($name, 'glide:'))
+            ->mapWithKeys(fn ($value, $name) => [str_replace('glide:', '', $name) => $value])
+            ->toArray();
     }
 
     private function getAttributeString(): string

--- a/tests/__snapshots__/ResponsiveTagTest__it_can_add_custom_glide_parameters__1.txt
+++ b/tests/__snapshots__/ResponsiveTagTest__it_can_add_custom_glide_parameters__1.txt
@@ -28,7 +28,7 @@
                         
     <img
         
-        src="/img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=/test.jpg?w=340&amp;h=280"
+        src="/img/asset/dGVzdF9jb250YWluZXIvdGVzdC5qcGc=/test.jpg?blur=10&amp;w=340&amp;h=280"
                 alt="test.jpg"
                  width="340"          height="280"                 data-statamic-responsive-images
             >


### PR DESCRIPTION
This PR closes https://github.com/spatie/statamic-responsive-images/issues/251 and ensures that glide parameters are also applied to the `src` image. This is particularly helpful for parameters like watermark.