### PR TITLE
Move placeholder generation into job

### DIFF
--- a/src/Jobs/GeneratePlaceholderJob.php
+++ b/src/Jobs/GeneratePlaceholderJob.php
@@ -3,16 +3,16 @@
 namespace Spatie\ResponsiveImages\Jobs;
 
 use Illuminate\Bus\Queueable;
-use Statamic\Contracts\Assets\Asset;
-use Statamic\Imaging\ImageGenerator;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Config;
 use Spatie\ResponsiveImages\Breakpoint;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Statamic\Exceptions\NotFoundHttpException;
 use Spatie\ResponsiveImages\DimensionCalculator;
+use Statamic\Contracts\Assets\Asset;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Imaging\ImageGenerator;
 
 class GeneratePlaceholderJob implements ShouldQueue
 {

--- a/src/Jobs/GeneratePlaceholderJob.php
+++ b/src/Jobs/GeneratePlaceholderJob.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Spatie\ResponsiveImages\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Statamic\Contracts\Assets\Asset;
+use Statamic\Imaging\ImageGenerator;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Config;
+use Spatie\ResponsiveImages\Breakpoint;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Statamic\Exceptions\NotFoundHttpException;
+use Spatie\ResponsiveImages\DimensionCalculator;
+
+class GeneratePlaceholderJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(protected Asset $asset, protected Breakpoint $breakpoint)
+    {
+        $this->queue = config('statamic.responsive-images.queue', 'default');
+    }
+
+    public function handle(): string
+    {
+        $dimensions = app(DimensionCalculator::class)
+            ->calculateForPlaceholder($this->breakpoint);
+
+        $params = [
+            'w' => $dimensions->getWidth(),
+            'h' => $dimensions->getHeight(),
+            'blur' => 5,
+            /**
+             * Arbitrary parameter to change md5 hash for Glide manipulation cache key
+             * to force Glide to generate new manipulated image if cache setting changes.
+             * TODO: Remove this line once the issue has been resolved in statamic/cms package
+             */
+            'cache' => Config::get('statamic.assets.image_manipulation.cache', false),
+        ];
+
+        try {
+            return app(ImageGenerator::class)->generateByAsset($this->asset, $params);
+        } catch (NotFoundHttpException $e) {
+            return '';
+        }
+    }
+}

--- a/src/Source.php
+++ b/src/Source.php
@@ -51,9 +51,7 @@ class Source implements Arrayable
     public function getSrcSet(string $format = null, ?bool $includePlaceholder = null): ?string
     {
         // In order of importance: override (e.g. from GraphQL), breakpoint param, config
-        $includePlaceholder = $includePlaceholder
-            ?? $this->breakpoint->parameters['placeholder']
-            ?? config('statamic.responsive-images.placeholder', false);
+        $includePlaceholder = $includePlaceholder ?? $this->includePlaceholder();
 
         $dimensionsCollection = $this->getDimensions();
 
@@ -116,6 +114,16 @@ class Source implements Arrayable
         $this->getDimensions()->map(function (Dimensions $dimensions) use ($format) {
             dispatch($this->buildImageJob($dimensions->width, $dimensions->height, $format));
         });
+
+        if ($this->includePlaceholder()) {
+            dispatch($this->breakpoint->buildPlaceholderJob());
+        }
+    }
+
+    private function includePlaceholder(): bool
+    {
+        return $this->breakpoint->parameters['placeholder']
+            ?? config('statamic.responsive-images.placeholder', false);
     }
 
     public function toGql(array $args)


### PR DESCRIPTION
As discussed in https://github.com/spatie/statamic-responsive-images/issues/253, this PR moves the placeholder generation into a job than can be dispatched when using the `php please responsive:generate` command. 

I've tested it with both glide caching on and off. The  arbitrary `cache` parameter is still needed to not break the placeholder when switching between cache on/off.

BTW, this is for the same site that @jackmcdade mentioned in the recent discussion.