### PR TITLE
Update AssetNotFoundException to accept $assetParam as array

### DIFF
--- a/src/AssetNotFoundException.php
+++ b/src/AssetNotFoundException.php
@@ -8,6 +8,10 @@ class AssetNotFoundException extends Exception
 {
     public static function create($assetParam)
     {
+        if (is_array($assetParam)) {
+            $assetParam = $assetParam['url'] ?? '';
+        }
+
         return new self("Could not find asset {$assetParam}");
     }
 }


### PR DESCRIPTION
The Responsive::retrieveAsset() method accepts an array as the $assetParam argument, however the AssetNotFoundException assumes the $assetParam argument is a string. This results in an "array to string conversion" error when the exception is being created.

https://github.com/spatie/statamic-responsive-images/blob/main/src/Responsive.php#L91-L93

